### PR TITLE
Replace memmap with memmap2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ nix = "0.13.1"
 libc = "0.2.74"
 memoffset = "0.5.1"
 byteorder = "1.3.2"
-memmap = "0.7.0"
+memmap2 = "0.2.2"
 goblin = "0.1.2"
 thiserror = "1.0.21"
 

--- a/src/maps_reader.rs
+++ b/src/maps_reader.rs
@@ -3,7 +3,7 @@ use crate::errors::MapsReaderError;
 use crate::thread_info::Pid;
 use byteorder::{NativeEndian, ReadBytesExt};
 use goblin::elf;
-use memmap::{Mmap, MmapOptions};
+use memmap2::{Mmap, MmapOptions};
 use std::convert::TryInto;
 use std::fs::File;
 use std::mem::size_of;


### PR DESCRIPTION
The crate [memmap](https://crates.io/crates/memmap) has been marked unmaintained, see the [advisory](https://rustsec.org/advisories/RUSTSEC-2020-0077).

This PR replaces the dependency with [memmap2](https://crates.io/crates/memmap2), which is a maintained fork of memmap.