### PR TITLE
Cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 [dependencies]
 byteorder = "1.3.2"
 cfg-if = "1.0"
-memoffset = "0.5.1"
+memoffset = "0.6"
 minidump-common = "0.10"
 scroll = "0.11"
 tempfile = "3.1.0"
@@ -16,8 +16,8 @@ thiserror = "1.0.21"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.74"
-goblin = "0.1.2"
-memmap2 = "0.2.2"
+goblin = "0.5"
+memmap2 = "0.5"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 nix = "0.23"

--- a/src/linux/crash_context.rs
+++ b/src/linux/crash_context.rs
@@ -1,6 +1,6 @@
 //! Minidump defines register structures which are different from the raw
 //! structures which we get from the kernel. These are platform specific
-//! functions to juggle the ucontext_t and user structures into minidump format.
+//! functions to juggle the `ucontext_t` and user structures into minidump format.
 
 #![allow(non_camel_case_types)]
 

--- a/src/linux/dso_debug.rs
+++ b/src/linux/dso_debug.rs
@@ -124,7 +124,7 @@ pub fn write_dso_debug_stream(
 
     // Assume the program base is at the beginning of the same page as the PHDR
     let mut base = phdr & !0xfff;
-    let mut dyn_addr = 0 as ElfAddr;
+    let mut dyn_addr = 0;
     // Search for the program PT_DYNAMIC segment
     for ph in program_headers {
         // Adjust base address with the virtual address of the PT_LOAD segment
@@ -217,7 +217,7 @@ pub fn write_dso_debug_stream(
     }
 
     let mut linkmap_rva = u32::MAX;
-    if dso_vec.len() > 0 {
+    if !dso_vec.is_empty() {
         // If we have at least one DSO, create an array of MDRawLinkMap
         // entries in the minidump file.
         let mut linkmap = MemoryArrayWriter::<MDRawLinkMap>::alloc_array(buffer, dso_vec.len())?;

--- a/src/linux/minidump_writer.rs
+++ b/src/linux/minidump_writer.rs
@@ -299,7 +299,7 @@ impl MinidumpWriter {
         // we should have a mostly-intact dump
         dir_section.write_to_file(buffer, None)?;
 
-        let dirent = thread_list_stream::write(self, buffer, &dumper)?;
+        let dirent = thread_list_stream::write(self, buffer, dumper)?;
         // Write section to file
         dir_section.write_to_file(buffer, Some(dirent))?;
 
@@ -307,7 +307,7 @@ impl MinidumpWriter {
         // Write section to file
         dir_section.write_to_file(buffer, Some(dirent))?;
 
-        let _ = app_memory::write(self, buffer)?;
+        app_memory::write(self, buffer)?;
         // Write section to file
         dir_section.write_to_file(buffer, None)?;
 
@@ -413,6 +413,7 @@ impl MinidumpWriter {
         Ok(())
     }
 
+    #[allow(clippy::unused_self)]
     fn write_file(
         &self,
         buffer: &mut DumpBuf,

--- a/src/linux/sections/exception_stream.rs
+++ b/src/linux/sections/exception_stream.rs
@@ -94,8 +94,8 @@ pub fn write(
     };
 
     let thread_context = match config.crashing_thread_context {
-        CrashingThreadContext::CrashContextPlusAddress((ctx, _)) => ctx,
-        CrashingThreadContext::CrashContext(ctx) => ctx,
+        CrashingThreadContext::CrashContextPlusAddress((ctx, _))
+        | CrashingThreadContext::CrashContext(ctx) => ctx,
         CrashingThreadContext::None => MDLocationDescriptor {
             data_size: 0,
             rva: 0,

--- a/src/linux/sections/mappings.rs
+++ b/src/linux/sections/mappings.rs
@@ -41,7 +41,7 @@ pub fn write(
     for user in &config.user_mapping_list {
         // GUID was provided by caller.
         let module = fill_raw_module(buffer, &user.mapping, &user.identifier)?;
-        modules.push(module)
+        modules.push(module);
     }
 
     let list_header = MemoryWriter::<u32>::alloc_with_val(buffer, modules.len() as u32)?;
@@ -64,10 +64,9 @@ fn fill_raw_module(
     mapping: &MappingInfo,
     identifier: &[u8],
 ) -> Result<MDRawModule, errors::SectionMappingsError> {
-    let cv_record: MDLocationDescriptor;
-    if identifier.is_empty() {
+    let cv_record = if identifier.is_empty() {
         // Just zeroes
-        cv_record = Default::default();
+        Default::default()
     } else {
         let cv_signature = crate::minidump_format::format::CvSignature::Elf as u32;
         let array_size = std::mem::size_of_val(&cv_signature) + identifier.len();
@@ -81,8 +80,8 @@ fn fill_raw_module(
         {
             sig_section.set_value_at(buffer, *val, index)?;
         }
-        cv_record = sig_section.location();
-    }
+        sig_section.location()
+    };
 
     let (file_path, _) = mapping
         .get_mapping_effective_name_and_path()

--- a/src/linux/sections/thread_list_stream.rs
+++ b/src/linux/sections/thread_list_stream.rs
@@ -232,7 +232,7 @@ fn fill_thread_stack(
         buffer.write_all(&stack_bytes);
         thread.stack.start_of_memory_range = stack as u64;
         thread.stack.memory = stack_location;
-        config.memory_blocks.push(thread.stack.clone());
+        config.memory_blocks.push(thread.stack);
     }
     Ok(())
 }

--- a/src/linux/sections/thread_names_stream.rs
+++ b/src/linux/sections/thread_names_stream.rs
@@ -21,7 +21,7 @@ pub fn write(
 
     for (idx, item) in dumper.threads.iter().enumerate() {
         if let Some(name) = &item.name {
-            let pos = write_string_to_location(buffer, &name)?;
+            let pos = write_string_to_location(buffer, name)?;
             let thread = MDRawThreadName {
                 thread_id: item.tid.try_into()?,
                 thread_name_rva: pos.rva.into(),

--- a/src/linux/thread_info.rs
+++ b/src/linux/thread_info.rs
@@ -69,13 +69,13 @@ trait CommonThreadInfo {
                     tgid = l
                         .get(6..)
                         .ok_or_else(|| ThreadInfoError::InvalidProcStatusFile(tid, l.clone()))?
-                        .parse::<Pid>()?
+                        .parse::<Pid>()?;
                 }
                 "PPid:\t" => {
                     ppid = l
                         .get(6..)
                         .ok_or_else(|| ThreadInfoError::InvalidProcStatusFile(tid, l.clone()))?
-                        .parse::<Pid>()?
+                        .parse::<Pid>()?;
                 }
                 _ => continue,
             }
@@ -106,7 +106,7 @@ trait CommonThreadInfo {
                 request as ptrace::RequestType,
                 libc::pid_t::from(pid),
                 flag.unwrap_or(NT_Elf::NT_NONE),
-                data.as_mut_ptr() as *const _ as *const libc::c_void,
+                data.as_mut_ptr(),
             )
         };
         Errno::result(res)?;
@@ -123,9 +123,9 @@ trait CommonThreadInfo {
         flag: Option<NT_Elf>,
         pid: nix::unistd::Pid,
     ) -> Result<T> {
-        let mut data = std::mem::MaybeUninit::uninit();
+        let mut data = std::mem::MaybeUninit::<T>::uninit();
         let io = libc::iovec {
-            iov_base: data.as_mut_ptr() as *mut libc::c_void,
+            iov_base: data.as_mut_ptr().cast(),
             iov_len: std::mem::size_of::<T>(),
         };
         let res = unsafe {
@@ -133,7 +133,7 @@ trait CommonThreadInfo {
                 request as ptrace::RequestType,
                 libc::pid_t::from(pid),
                 flag.unwrap_or(NT_Elf::NT_NONE),
-                &io as *const _ as *const libc::c_void,
+                &io as *const _,
             )
         };
         Errno::result(res)?;

--- a/src/linux/thread_info/x86.rs
+++ b/src/linux/thread_info/x86.rs
@@ -94,18 +94,18 @@ impl ThreadInfoX86 {
 
         let debug_offset = memoffset::offset_of!(user, u_debugreg);
         let elem_offset = size_of_val(&dregs[0]);
-        for idx in 0..NUM_DEBUG_REGISTERS {
+        for (idx, dreg) in dregs.iter_mut().enumerate() {
             let chunk = Self::peek_user(
                 tid,
                 (debug_offset + idx * elem_offset) as ptrace::AddressType,
             )?;
             #[cfg(target_arch = "x86_64")]
             {
-                dregs[idx] = chunk as u64; // libc / ptrace is very messy wrt int types used...
+                *dreg = chunk as u64; // libc / ptrace is very messy wrt int types used...
             }
             #[cfg(target_arch = "x86")]
             {
-                dregs[idx] = chunk as i32; // libc / ptrace is very messy wrt int types used...
+                *dreg = chunk as i32; // libc / ptrace is very messy wrt int types used...
             }
         }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -86,7 +86,7 @@ pub fn start_child_and_return(command: &str) -> Child {
         .arg("--bin")
         .arg("test")
         .arg("--")
-        .arg(format!("{}", command))
+        .arg(command)
         .stdout(Stdio::piped())
         .spawn()
         .expect("failed to execute child");

--- a/tests/minidump_writer.rs
+++ b/tests/minidump_writer.rs
@@ -594,10 +594,7 @@ fn test_sanitized_stacks_helper(context: Context) {
         let start = mem.rva as usize;
         let end = (mem.rva + mem.data_size) as usize;
         let slice = &dump_array.as_slice()[start..end];
-        assert!(slice
-            .windows(defaced.len())
-            .position(|window| window == defaced)
-            .is_some());
+        assert!(slice.windows(defaced.len()).any(|window| window == defaced));
     }
 }
 #[test]


### PR DESCRIPTION
Follow up to #15, this bumps outdated dependencies (no changes needed), and fixes all clippy lints, at least when targeting x86_64