### PR TITLE
Use unified crash-context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 [dependencies]
 byteorder = "1.3.2"
 cfg-if = "1.0"
-crash-context = { git = "https://github.com/EmbarkStudios/crash-handling", branch = "impl" }
+crash-context = "0.0.1"
 memoffset = "0.6"
 minidump-common = "0.10"
 scroll = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 [dependencies]
 byteorder = "1.3.2"
 cfg-if = "1.0"
+crash-context = { git = "https://github.com/EmbarkStudios/crash-handling", branch = "impl" }
 memoffset = "0.6"
 minidump-common = "0.10"
 scroll = "0.11"

--- a/src/linux/crash_context.rs
+++ b/src/linux/crash_context.rs
@@ -2,55 +2,18 @@
 //! structures which we get from the kernel. These are platform specific
 //! functions to juggle the `ucontext_t` and user structures into minidump format.
 
-#![allow(non_camel_case_types)]
+pub struct CrashContext {
+    pub inner: crash_context::CrashContext,
+}
 
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "x86_64")] {
-        pub(crate) mod x86_64;
-
-        pub type fpstate_t = libc::user_fpregs_struct;
+        mod x86_64;
     } else if #[cfg(target_arch = "x86")] {
-        pub(crate) mod x86;
-
-        pub type fpstate_t = libc::_libc_fpstate;
-    } else if #[cfg(target_arch = "arm")] {
-        pub(crate) mod arm;
+        mod x86;
     } else if #[cfg(target_arch = "aarch64")] {
-        pub(crate) mod aarch64;
-
-        /// Magic value written by the kernel and our custom getcontext
-        pub const FPSIMD_MAGIC: u32 = 0x46508001;
-
-        #[repr(C)]
-        #[derive(Clone)]
-        pub struct _aarch64_ctx {
-            pub magic: u32,
-            pub size: u32,
-        }
-
-        #[repr(C)]
-        #[derive(Clone)]
-        pub struct fpsimd_context {
-            pub head: _aarch64_ctx,
-            pub fpsr: u32,
-            pub fpcr: u32,
-            pub vregs: [u128; 32],
-        }
-
-        pub type fpstate_t = fpsimd_context;
+        mod aarch64;
+    } else if #[cfg(target_arch = "arm")] {
+        mod arm;
     }
-}
-
-#[repr(C)]
-#[derive(Clone)]
-pub struct CrashContext {
-    pub siginfo: libc::siginfo_t,
-    pub tid: libc::pid_t, // the crashing thread.
-    #[cfg(not(target_arch = "arm"))]
-    pub context: libc::ucontext_t,
-    // #ifdef this out because FP state is not part of user ABI for Linux ARM.
-    // In case of MIPS Linux FP state is already part of ucontext_t so
-    // 'float_state' is not required.
-    #[cfg(not(target_arch = "arm"))]
-    pub float_state: fpstate_t,
 }

--- a/src/linux/crash_context/aarch64.rs
+++ b/src/linux/crash_context/aarch64.rs
@@ -6,23 +6,29 @@ use crate::{
 
 impl CrashContext {
     pub fn get_instruction_pointer(&self) -> usize {
-        self.context.uc_mcontext.pc as usize
+        self.inner.context.uc_mcontext.pc as usize
     }
 
     pub fn get_stack_pointer(&self) -> usize {
-        self.context.uc_mcontext.sp as usize
+        self.inner.context.uc_mcontext.sp as usize
     }
 
     pub fn fill_cpu_context(&self, out: &mut RawContextCPU) {
         out.context_flags = format::ContextFlagsArm64Old::CONTEXT_ARM64_OLD_FULL.bits() as u64;
 
-        out.cpsr = self.context.uc_mcontext.pstate as u32;
-        out.iregs[..GP_REG_COUNT].copy_from_slice(&self.context.uc_mcontext.regs[..GP_REG_COUNT]);
-        out.sp = self.context.uc_mcontext.sp;
-        out.pc = self.context.uc_mcontext.pc;
+        {
+            let gregs = &self.inner.context.uc_mcontext;
+            out.cpsr = gregs.pstate as u32;
+            out.iregs[..GP_REG_COUNT].copy_from_slice(&gregs.regs[..GP_REG_COUNT]);
+            out.sp = gregs.sp;
+            out.pc = gregs.pc;
+        }
 
-        out.fpsr = self.float_state.fpsr;
-        out.fpcr = self.float_state.fpcr;
-        out.float_regs[..FP_REG_COUNT].copy_from_slice(&self.float_state.vregs[..FP_REG_COUNT]);
+        {
+            let fs = &self.inner.float_state;
+            out.float_save.fpsr = fs.fpsr;
+            out.float_save.fpcr = fs.fpcr;
+            out.float_save.regs[..FP_REG_COUNT].copy_from_slice(&fs.vregs[..FP_REG_COUNT]);
+        }
     }
 }

--- a/src/linux/crash_context/x86.rs
+++ b/src/linux/crash_context/x86.rs
@@ -6,11 +6,11 @@ use libc::{
 };
 impl CrashContext {
     pub fn get_instruction_pointer(&self) -> usize {
-        self.context.uc_mcontext.gregs[REG_EIP as usize] as usize
+        self.inner.context.uc_mcontext.gregs[REG_EIP as usize] as usize
     }
 
     pub fn get_stack_pointer(&self) -> usize {
-        self.context.uc_mcontext.gregs[REG_ESP as usize] as usize
+        self.inner.context.uc_mcontext.gregs[REG_ESP as usize] as usize
     }
 
     pub fn fill_cpu_context(&self, out: &mut RawContextCPU) {
@@ -18,7 +18,7 @@ impl CrashContext {
             | ContextFlagsX86::CONTEXT_X86_FLOATING_POINT.bits();
 
         {
-            let gregs = &self.context.uc_mcontext.gregs;
+            let gregs = &self.inner.context.uc_mcontext.gregs;
             out.gs = gregs[REG_GS as usize] as u32;
             out.fs = gregs[REG_FS as usize] as u32;
             out.es = gregs[REG_ES as usize] as u32;
@@ -40,7 +40,7 @@ impl CrashContext {
         }
 
         {
-            let fs = &self.float_state;
+            let fs = &self.inner.float_state;
             let mut out = &mut out.float_save;
             out.control_word = fs.cw;
             out.status_word = fs.sw;

--- a/src/linux/crash_context/x86_64.rs
+++ b/src/linux/crash_context/x86_64.rs
@@ -10,18 +10,18 @@ use scroll::Pwrite;
 
 impl CrashContext {
     pub fn get_instruction_pointer(&self) -> usize {
-        self.context.uc_mcontext.gregs[REG_RIP as usize] as usize
+        self.inner.context.uc_mcontext.gregs[REG_RIP as usize] as usize
     }
 
     pub fn get_stack_pointer(&self) -> usize {
-        self.context.uc_mcontext.gregs[REG_RSP as usize] as usize
+        self.inner.context.uc_mcontext.gregs[REG_RSP as usize] as usize
     }
 
     pub fn fill_cpu_context(&self, out: &mut RawContextCPU) {
         out.context_flags = format::ContextFlagsAmd64::CONTEXT_AMD64_FULL.bits();
 
         {
-            let gregs = &self.context.uc_mcontext.gregs;
+            let gregs = &self.inner.context.uc_mcontext.gregs;
             out.cs = (gregs[REG_CSGSFS as usize] & 0xffff) as u16;
 
             out.fs = ((gregs[REG_CSGSFS as usize] >> 32) & 0xffff) as u16;
@@ -51,7 +51,7 @@ impl CrashContext {
         }
 
         {
-            let fs = &self.float_state;
+            let fs = &self.inner.float_state;
 
             let mut float_save = format::XMM_SAVE_AREA32 {
                 control_word: fs.cwd,

--- a/src/linux/dumper_cpu_info/arm.rs
+++ b/src/linux/dumper_cpu_info/arm.rs
@@ -1,4 +1,5 @@
 use crate::{errors::CpuInfoError, minidump_format::*};
+use scroll::Pwrite;
 use std::{
     collections::HashSet,
     fs::File,
@@ -269,7 +270,6 @@ pub fn write_cpu_information(sys_info: &mut MDRawSystemInfo) -> Result<()> {
     //  pub cpuid: u32,
     //  pub elf_hwcaps: u32,
     // }
-    use scroll::Pwrite;
     sys_info
         .cpu
         .data

--- a/src/linux/sections/exception_stream.rs
+++ b/src/linux/sections/exception_stream.rs
@@ -66,11 +66,11 @@ pub fn write(
         }
         #[cfg(not(target_arch = "arm"))]
         {
-            sig_addr = unsafe { context.siginfo.si_addr() } as u64;
+            sig_addr = context.inner.siginfo.ssi_addr as u64;
         }
         MDException {
-            exception_code: context.siginfo.si_signo as u32,
-            exception_flags: context.siginfo.si_code as u32,
+            exception_code: context.inner.siginfo.ssi_signo as u32,
+            exception_flags: context.inner.siginfo.ssi_code as u32,
             exception_record: 0,
             exception_address: sig_addr,
             number_parameters: 0,

--- a/src/linux/thread_info/x86.rs
+++ b/src/linux/thread_info/x86.rs
@@ -248,7 +248,6 @@ impl ThreadInfoX86 {
         out.float_save.data_offset = self.fpregs.foo as u32;
         out.float_save.data_selector = self.fpregs.fos as u32;
 
-        use scroll::Pwrite;
         {
             let ra = &mut out.float_save.register_area;
             // 8 registers * 10 bytes per register.


### PR DESCRIPTION
This builds on #16 to use the `CrashContext` from [here](https://github.com/EmbarkStudios/crash-handling/blob/impl/crash-context/src/linux.rs) as it allows a single crash context to be shared between different crates, without needing to rely on `minidump-writer` itself, and implements getcontext for targets that don't directly support it such as musl and android.

Resolves: #4